### PR TITLE
Adaptation to Windows

### DIFF
--- a/piapy/piapy.py
+++ b/piapy/piapy.py
@@ -2,7 +2,12 @@ import random
 import subprocess
 from itertools import cycle
 from time import sleep
+from platform import system
 
+# Change the piactl path if executing on Windows
+piapath = "piactl"
+if system()=='Windows':
+    piapath = "C:\Program Files\Private Internet Access\piactl.exe"
 
 class PiaVpn:
     def __init__(self):
@@ -14,14 +19,15 @@ class PiaVpn:
         get VPN servers available
         :return:
         """
+        cmd = [piapath, "get", "regions"]
         process = subprocess.run(
-            ["piactl get regions"], shell=True, capture_output=True
+            cmd, shell=True, capture_output=True
         )
 
         if process.returncode != 0:
             raise SystemError(process.stderr.decode("utf-8"))
         else:
-            regions = process.stdout.decode("utf-8").split("\n")
+            regions = [e.strip('\r') for e in process.stdout.decode("utf-8").split("\n")]
             regions.remove("auto")
             regions.remove("")
 
@@ -29,11 +35,12 @@ class PiaVpn:
 
     @staticmethod
     def region():
-        process = subprocess.run(["piactl get region"], shell=True, capture_output=True)
+        cmd = [piapath, "get", "region"]
+        process = subprocess.run(cmd, shell=True, capture_output=True)
         if process.returncode != 0:
             raise SystemError(process.stderr.decode("utf-8"))
         else:
-            return process.stdout.decode("utf-8").replace("\n", "")
+            return process.stdout.decode("utf-8").replace("\n", "").strip('\r')
 
     def set_region(self, server=None):
 
@@ -45,8 +52,8 @@ class PiaVpn:
         elif server not in regions:
             raise ConnectionError("Server must be one of: {}".format(regions))
 
-        args = "piactl set region {}".format(server)
-        process = subprocess.run([args], shell=True, capture_output=True)
+        cmd = [piapath, "set", "region", server]
+        process = subprocess.run(cmd, shell=True, capture_output=True)
 
         if process.returncode != 0:
             raise SystemError(process.stderr.decode("utf-8"))
@@ -55,23 +62,25 @@ class PiaVpn:
 
     @staticmethod
     def status():
+        cmd = [piapath, "get", "connectionstate"]
         process = subprocess.run(
-            ["piactl get connectionstate"], shell=True, capture_output=True
+            cmd, shell=True, capture_output=True
         )
 
         if process.returncode != 0:
             raise SystemError(process.stderr.decode("utf-8"))
         else:
-            return process.stdout.decode("utf-8").replace("\n", "")
+            return process.stdout.decode("utf-8").replace("\n", "").strip('\r')
 
     @staticmethod
     def ip():
-        process = subprocess.run(["piactl get vpnip"], shell=True, capture_output=True)
+        cmd = [piapath, "get", "vpnip"]
+        process = subprocess.run(cmd, shell=True, capture_output=True)
 
         if process.returncode != 0:
             raise SystemError(process.stderr.decode("utf-8"))
         else:
-            return process.stdout.decode("utf-8").replace("\n", "")
+            return process.stdout.decode("utf-8").replace("\n", "").strip('\r')
 
     def connect(self, timeout=20, verbose=False):
         """
@@ -84,8 +93,9 @@ class PiaVpn:
             raise SystemError(
                 'Args have some problems, check them. "timeout" must be integer and "verbose" must be boolean.'
             )
-
-        process = subprocess.run(["piactl connect"], shell=True, capture_output=True)
+        
+        cmd = [piapath, "connect"]
+        process = subprocess.run(cmd, shell=True, capture_output=True)
         if process.returncode != 0:
             raise SystemError(process.stderr.decode("utf-8"))
         else:
@@ -115,7 +125,8 @@ class PiaVpn:
 
     @staticmethod
     def disconnect():
-        process = subprocess.run(["piactl disconnect"], shell=True, capture_output=True)
+        cmd = [piapath, "disconnect"]
+        process = subprocess.run(cmd, shell=True, capture_output=True)
 
         if process.returncode != 0:
             raise SystemError(process.stderr.decode("utf-8"))
@@ -124,9 +135,8 @@ class PiaVpn:
 
     @staticmethod
     def reset_settings():
-        process = subprocess.run(
-            ["piactl resetsettings"], shell=True, capture_output=True
-        )
+        cmd = [piapath, "resetsettings"]
+        process = subprocess.run(cmd, shell=True, capture_output=True)
 
         if process.returncode != 0:
             raise SystemError(process.stderr.decode("utf-8"))
@@ -139,8 +149,8 @@ class PiaVpn:
         if not isinstance(value, bool):
             raise SystemError('Arg "value" must be a boolean.')
 
-        args = "piactl set debuglogging {}".format(str(value).lower())
-        process = subprocess.run([args], shell=True, capture_output=True)
+        cmd = [piapath, "set", "debuglogging", str(value).lower()]
+        process = subprocess.run(cmd, shell=True, capture_output=True)
 
         if process.returncode != 0:
             raise SystemError(process.stderr.decode("utf-8"))


### PR DESCRIPTION
The package didn't work on Windows (at least not on my Windows 10).

Here are the changes I made:
- At the beginning of the script, we now check the platform and change the path of _piactl_.
   I use the default full path of _piactl_, following the recommendations of PIA.
- I changed the way the commands are forged before execution to make it work with the full path of _piactl_ on Windows (no impact on other platforms)
- I also added some _**.strip('\r')**_ to the results to clean the outputs on Windows.